### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Goose reads its provider and model configuration from:
 
 Questions or issues? Open an issue on [GitHub](https://github.com/block/vscode-goose/issues).
 
+## Spectator phone (Build Remote Agent)
+
+This extension stays a thin ACP bridge to the local Goose CLI. To spectate the **desktop** Goose session from a phone, pair [Build Remote Agent](https://grokbuildremote.com/) via the free MIT [`gbr-agent`](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Protocol `gbr/1`. Phone is spectator + veto, not orchestrator. Independent product — not affiliated with xAI or SpaceX. No extra VS Code UI.
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # need v0.6.0+
+gbr-agent pair && gbr-agent run
+curl -sS http://127.0.0.1:8788/health
+```
+
+Attach only `http://127.0.0.1:8788` or stdio `gbr-mcp`. Unpair in the phone app before switching PCs. Never commit mailbox keys.
+
 ## License
 
 Apache-2.0 — see [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
 # Goose for VS Code
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 Bring [Goose](https://goose-docs.ai/)—the open-source, on-device AI agent—directly into your editor. Chat with Goose, reference your code, and let it handle full-stack engineering tasks without ever leaving VS Code.
 
 ![Screenshot](./resources/screenshot.gif)
@@ -96,15 +123,16 @@ Questions or issues? Open an issue on [GitHub](https://github.com/block/vscode-g
 
 This extension stays a thin ACP bridge to the local Goose CLI. To spectate the **desktop** Goose session from a phone, pair [Build Remote Agent](https://grokbuildremote.com/) via the free MIT [`gbr-agent`](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Protocol `gbr/1`. Phone is spectator + veto, not orchestrator. Independent product — not affiliated with xAI or SpaceX. No extra VS Code UI.
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version          # need v0.6.0+
-gbr-agent pair && gbr-agent run
-curl -sS http://127.0.0.1:8788/health
-```
 
 Attach only `http://127.0.0.1:8788` or stdio `gbr-mcp`. Unpair in the phone app before switching PCs. Never commit mailbox keys.
 
 ## License
 
 Apache-2.0 — see [LICENSE](./LICENSE)
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html


### PR DESCRIPTION
## What

README subsection only. This extension stays a thin ACP bridge. A phone running **Build Remote Agent** can spectate the desktop Goose session via `gbr-agent`. No new VS Code UI.

## How

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version          # v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

Attach only `http://127.0.0.1:8788` or stdio `gbr-mcp`. Phone is spectator + veto. Protocol `gbr/1`.

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX. No mailbox keys.